### PR TITLE
[Project-Star-Wars-Planets-Search]-Felipe-Louzeiro

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -28,7 +28,7 @@ const mockFetch = () => {
     }));
 }
 
-describe('1 - Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`', () => {
+describe.only('1 - Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`', () => {
   beforeAll(mockFetch);
   beforeEach(cleanup);
 

--- a/src/componentes/FetchApi.js
+++ b/src/componentes/FetchApi.js
@@ -1,0 +1,8 @@
+export const api = 'https://swapi-trybe.herokuapp.com/api/planets/';
+
+export const requestApi = async () => {
+  const response = await fetch(api);
+  const data = await response.json();
+  delete data.residents;
+  return data;
+};

--- a/src/context/Context.js
+++ b/src/context/Context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const SWContext = createContext();
+
+export default SWContext;

--- a/src/context/Provider.js
+++ b/src/context/Provider.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import SWContext from './Context';
+
+function SWProvider({ children }) {
+  const context = {};
+
+  return (
+    <SWContext.Provider value={ context }>
+      {children}
+    </SWContext.Provider>
+  );
+}
+SWProvider.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default SWProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import SWProvider from './context/Provider';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <SWProvider>
+    <App />
+  </SWProvider>,
+  document.getElementById('root'),
+);


### PR DESCRIPTION
[ ] 1 - Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`.

[ ] 2 - Filtre a tabela através de um texto, inserido num *campo de texto*, exibindo somente os planetas cujos nomes incluam o texto digitado.

[ ] 3  - Crie um filtro para valores numéricos.

[ ] 4 - Não utilize filtros repetidos.

[ ] 5 - Apague o filtro de valores numéricos e desfaça as filtragens dos dados da tabela ao clicar no ícone de `X` de um dos filtros.

[ ] 6 - Ordene as colunas de forma ascendente ou descendente.
